### PR TITLE
bug949622 - Display what locale version/date is being used in healthcheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "webmaker-download-locales": "0.1.2",
     "webmaker-i18n": "https://github.com/mozilla/node-webmaker-i18n/archive/v0.3.12.tar.gz",
     "webmaker-locale-mapping": "latest",
+    "webmaker-translation-stats": "0.0.1",
     "prerender-node": "0.1.18",
     "newrelic": "1.4.0"
   },

--- a/server/config.js
+++ b/server/config.js
@@ -5,6 +5,7 @@ module.exports = function (env) {
   var app = express();
   var defaultLang = 'en-US';
   var csp = require('./csp');
+  var wts = require('webmaker-translation-stats');
 
   app.use(require('prerender-node'));
   app.use(express.logger('dev'));
@@ -37,7 +38,14 @@ module.exports = function (env) {
   };
 
   app.get('/healthcheck', function (req, res) {
-    res.json(healthcheck);
+    wts(i18n.getSupportLanguages(), path.join(__dirname, '../locale'), function(err, data) {
+      if(err) {
+        healthcheck.locales = err.toString();
+      } else {
+        healthcheck.locales = data;
+      }
+      res.json(healthcheck);
+    });
   });
 
   // Serve up virtual configuration "file"


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=949622
