### PR TITLE
Add HSTS, security headers and new options in config.  ( bug 1018391 )

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -34,5 +34,16 @@ SESSION_SECRET="dummy secret value"
 # Webmaker login URL
 LOGIN_URL=http://localhost:3000
 
-# Force ssl?
+# Force ssl?  If set to false, be sure HSTS_DISABLED is set to 'true'
 FORCE_SSL=false
+
+# Disable HSTS? (set to 'true' to disable HSTS)
+HSTS_DISABLED='true'
+
+# Use Deny settings for X-Frame headers?
+# set to 'true' to disable X-frames-options denial
+DISABLE_XFO_HEADERS_DENY='false'
+
+# Use default XSS protection?
+# set to 'true' to disable IEXSS protection
+IEXSS_PROTECTION_DISABLED='false'

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To run the service locally:
 
 To pass configuration to the server, `cp .env-dist .env` or create a `.env` file in the root directory.
 
-This app takes four configuration parameters, all of which are optional.
+This app takes a number of configuration parameters, all of which are optional.
 
 `PORT` - Where to run the server
 
@@ -45,6 +45,11 @@ This app takes four configuration parameters, all of which are optional.
 
 `GA_DOMAIN` = The domain for the your Google Analytics property
 
+`HSTS_DISABLED` = 'false'/'true'  -- To disable HSTS set to 'true' (if you are not forcing SSL, you should keep this set to true)
+
+`DISABLE_XFO_HEADERS_DENY` = 'false'/'true'  -- To disable x-frame-options headers being set to deny, set this to 'true'
+
+`IEXSS_PROTECTION_DISABLED` = 'false'/'true'   -- To disable IEXSS protection headers, set this to 'true'
 
 ## Grunt Tasks
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "grunt-shell-spawn": "0.3.0",
     "grunt-angular-i18n-finder": "0.0.3",
     "habitat": "1.1.0",
+    "helmet": "0.2.1",
     "hood": "0.2.1",
     "webmaker-auth": "0.0.12",
     "webmaker-download-locales": "0.1.2",

--- a/server/config.js
+++ b/server/config.js
@@ -7,6 +7,7 @@ module.exports = function (env) {
   var csp = require('./csp');
   var wts = require('webmaker-translation-stats');
   var WebmakerAuth = require('webmaker-auth');
+  var helmet = require('helmet');
 
   var auth = new WebmakerAuth({
     loginURL: env.get('LOGIN_URL'),
@@ -14,6 +15,17 @@ module.exports = function (env) {
     forceSSL: env.get('FORCE_SSL'),
     domain: env.get('COOKIE_DOMAIN')
   });
+
+  // Check for helmet security options
+  if (process.env.HSTS_DISABLED != 'true') {
+    app.use(helmet.hsts());
+  }
+  if (process.env.DISABLE_XFO_HEADERS_DENY != 'true') {
+    app.use(helmet.xframe('deny'));
+  }
+  if (process.env.IEXSS_PROTECTION_DISABLED != 'true') {
+    app.use(helmet.iexss());
+  }
 
   app.use(require('prerender-node'));
   app.use(express.logger('dev'));


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1018391

This adds three new config options:
# Disable HSTS? (set to 'true' to disable HSTS)

HSTS_DISABLED='true'
# Use Deny settings for X-Frame headers?
# set to 'true' to disable X-frames-options denial

DISABLE_XFO_HEADERS_DENY='false'
# Use default XSS protection?
# set to 'true' to disable IEXSS protection

IEXSS_PROTECTION_DISABLED='false'

This will allow us to turn these security headers on and off easily without deploying a new version.
